### PR TITLE
💥Remove a dumb scam reason

### DIFF
--- a/scammer.json
+++ b/scammer.json
@@ -11479,11 +11479,6 @@
         "reason": "Scammed 500 Coins",
         "uuid": "b2da6283af794ffba33dc1731082353f"
     },
-    "b2e649c823c745d08543cb827ce1b129": {
-        "operated_staff": "wise6174#7902",
-        "reason": "Advertised a livid dagger on their auction for 5m, which turned out to be a dreadlord sword",
-        "uuid": "b2e649c823c745d08543cb827ce1b129"
-    },
     "b2e7f59f71f6420a98a540537da84756": {
         "operated_staff": "deer#1500",
         "reason": "Scammed 1.6mil",


### PR DESCRIPTION
I see this as a really dumb reason for a ban of a friend of mine. It's really unfair to be excluded for advertising something that clearly was a joke. Your staff should honestly check more often what reasons are provided.
If you can please accept this pull request or at least check him again because I really feel this is unfair.
Thank you for getting through this.
Much appreciation for such a great community but this feels awful.